### PR TITLE
is_island returns True for nodes in middle of a graph

### DIFF
--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -147,7 +147,7 @@ class NodeBase(object):
         """
         Check if has no ancestors nor children
         """
-        return bool(not self.is_root() and not self.is_leaf())
+        return bool(not self.children.count() and not self.ancestors_set())
 
     def _get_roots(self, at):
         """


### PR DESCRIPTION
Previous implementation would return True for a node in the middle of a graph, that is a node that is was neither a leaf nor a root.  This wasn't correct as such a node has both children and ancestors.
