### PR TITLE
Allow circular check to be disabled

### DIFF
--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -38,8 +38,9 @@ class NodeBase(object):
         """
         args = kwargs
         args.update({'parent' : self, 'child' : descendant })
+        disable_check = args.pop('disable_circular_check', False)
         cls = self.children.through(**kwargs)
-        return cls.save()
+        return cls.save(disable_circular_check=disable_check)
 
 
     def add_parent(self, parent, *args, **kwargs):
@@ -230,7 +231,8 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
             return "%s is child of %s" % (self.child, self.parent)
 
         def save(self, *args, **kwargs):
-            self.parent.__class__.circular_checker(self.parent, self.child)
+            if not kwargs.pop('disable_circular_check', False):
+                self.parent.__class__.circular_checker(self.parent, self.child)
             super(Edge, self).save(*args, **kwargs) # Call the "real" save() method.
 
     return Edge


### PR DESCRIPTION
The circular check is a pretty expensive operation in the case of large graphs,
so allow it to be disabled via a keyword argument when adding DAG edges. This is
useful for cases when the user is absolutely sure that there are no cycles in
the graph, e.g. when importing a properly sanitized graph.
