### PR TITLE
Fix for Django 1.8 (also tested on 1.7)

### DIFF
--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -218,7 +218,7 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
         except IndexError:
             node_model_name = node_model
     else:
-        node_model_name = node_model._meta.module_name
+        node_model_name = node_model._meta.model_name
 
     class Edge(base_model):
         class Meta:

--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -7,8 +7,9 @@ Some ideas stolen from: from https://github.com/stdbrouw/django-treebeard-dag
 """
 
 
-from django.db import models
+import django
 from django.core.exceptions import ValidationError
+from django.db import models
 
 
 class NodeNotReachableException (Exception):
@@ -218,7 +219,7 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
         except IndexError:
             node_model_name = node_model
     else:
-    	# model._meta.module_name is deprecated in django version 1.7 and removed in django version 1.8.
+        # model._meta.module_name is deprecated in django version 1.7 and removed in django version 1.8.
         # It is replaced by model._meta.model_name
         if django.VERSION < (1, 7):
             node_model_name = node_model._meta.module_name

--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -218,7 +218,12 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
         except IndexError:
             node_model_name = node_model
     else:
-        node_model_name = node_model._meta.model_name
+    	# model._meta.module_name is deprecated in django version 1.7 and removed in django version 1.8.
+        # It is replaced by model._meta.model_name
+        if django.VERSION < (1, 7):
+            node_model_name = node_model._meta.module_name
+        else:
+            node_model_name = node_model._meta.model_name
 
     class Edge(base_model):
         class Meta:


### PR DESCRIPTION
  File "/usr/local/lib/python2.7/dist-packages/django_dag/models.py", line 221, in edge_factory
    node_model_name = node_model._meta.module_name
AttributeError: 'Options' object has no attribute 'module_name'