### PR TITLE
Fix edge_factory string type check

### DIFF
--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -212,7 +212,7 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
     """
     Dag Edge factory
     """
-    if isinstance(node_model, str):
+    if isinstance(node_model, basestring):
         try:
             node_model_name = node_model.split('.')[1]
         except IndexError:


### PR DESCRIPTION
Unicode class names weren't recognized (they are instances of `basestring` but not `str`)