### PR TITLE
Various changes

### DIFF
--- a/django_dag/tree_test_output.py
+++ b/django_dag/tree_test_output.py
@@ -1,0 +1,85 @@
+expected_tree_output = '''Content-Type: text/html; charset=utf-8\r
+\r
+# 1
+Descendants:
+# 5
+# 7
+
+
+
+# 2
+Descendants:
+# 8
+
+# 6
+# 8
+
+# 9
+
+# 7
+
+
+
+# 3
+Descendants:
+# 9
+
+# 7
+
+
+# 4
+Descendants:
+# 6
+# 8
+
+# 9
+
+# 7
+
+
+
+# 5
+
+# 6
+
+# 7
+
+Ancestors:
+# 3
+
+# 5
+# 1
+
+
+# 6
+# 2
+
+# 4
+
+
+# 8
+
+Ancestors:
+# 2
+
+# 6
+# 2
+
+# 4
+
+
+# 9
+
+Ancestors:
+# 3
+
+# 6
+# 2
+
+# 4
+
+
+# 10
+
+
+'''


### PR DESCRIPTION
Performance improvements:
* Cache intermediate `ancestors_set` and `descendants_set` results to prevent exponential blowup
* Added a test that checks for acceptable performance in deep graphs

Changes to `circular_checker`:
* Removed `'The object is a descendant'` error (it should be OK to add descendants as children) and changed related tests