### PR TITLE
Python 3 Compatibility 

### DIFF
--- a/django_dag/templatetags/dag_tags.py
+++ b/django_dag/templatetags/dag_tags.py
@@ -5,10 +5,6 @@ from django import template
 
 register = template.Library()
 
-from django import template
-
-register = template.Library()
-
 
 class RecurseDictNode(template.Node):
     def __init__(self, var, nodeList):
@@ -63,10 +59,11 @@ class RecurseDictNode(template.Node):
         output = self.renderCallback(context, vals, 1)
         return output
 
+
 def recursedict_tag(parser, token):
     bits = list(token.split_contents())
     if len(bits) != 2 and bits[0] != 'recursedict':
-        raise template.TemplateSyntaxError, "Invalid tag syntax expected '{% recursedict [dictVar] %}'"
+        raise template.TemplateSyntaxError("Invalid tag syntax expected '{% recursedict [dictVar] %}'")
 
     var = parser.compile_filter(bits[1])
     nodeList = {}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from distutils.core import setup
 
-version = '1.3'
+version = '1.4'
 
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This merge request adds Python 3 compatibility by changing the [syntax](https://docs.python.org/3.0/whatsnew/2.6.html#pep-3110) of how the exception is raised in the `dag_tags` template tag. I also removed the duplicate lines and incremented the version.